### PR TITLE
Use md5, not base-64, for Gravatar url hash.

### DIFF
--- a/13 - JavaScript Modules and Using npm/es6modules-FINISHED/package.json
+++ b/13 - JavaScript Modules and Using npm/es6modules-FINISHED/package.json
@@ -10,12 +10,12 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.12.0",
-    "base-64": "^0.1.0",
     "flickity": "^1.2.1",
     "insane": "^2.5.0",
     "jquery": "^3.0.0",
     "jsonp": "^0.2.0",
     "lodash": "^4.13.1",
+    "md5": "^2.1.0",
     "slug": "^0.9.1"
   },
   "devDependencies": {

--- a/13 - JavaScript Modules and Using npm/es6modules-FINISHED/src/user.js
+++ b/13 - JavaScript Modules and Using npm/es6modules-FINISHED/src/user.js
@@ -1,6 +1,6 @@
 import slug from 'slug';
 import { url } from './config';
-import base64 from 'base-64';
+import md5 from 'md5';
 
 export default function User(name, email, website) {
   return { name, email, website };
@@ -11,7 +11,7 @@ export function createURL(name) {
 }
 
 export function gravatar(email) {
-  const hash = base64.encode(email);
+  const hash = md5(email);
   const photoURL = `https://www.gravatar.com/avatar/${hash}`;
   return photoURL;
 }

--- a/13 - JavaScript Modules and Using npm/es6modules-FINISHED/src/user.js
+++ b/13 - JavaScript Modules and Using npm/es6modules-FINISHED/src/user.js
@@ -11,7 +11,7 @@ export function createURL(name) {
 }
 
 export function gravatar(email) {
-  const hash = md5(email);
+  const hash = md5(email.toLowerCase());
   const photoURL = `https://www.gravatar.com/avatar/${hash}`;
   return photoURL;
 }


### PR DESCRIPTION
[Gravatar uses md5, not base-64 to generate the URL.](http://en.gravatar.com/site/implement/hash/)