### PR TITLE
Fix SyntaxError thrown in Firefox

### DIFF
--- a/16 - Generators/generators.html
+++ b/16 - Generators/generators.html
@@ -29,7 +29,7 @@
 
   function* loop(arr) {
     console.log(inventors);
-    for (const item of arr) {
+    for (let item of arr) {
       yield item;
     }
   }


### PR DESCRIPTION
The following SyntaxError is thrown in Firefox 48+:
`SyntaxError: missing = in const declaration`
