### PR TITLE
Fix SyntaxError thrown in Firefox

### DIFF
--- a/16 - Generators/looping-generators.html
+++ b/16 - Generators/looping-generators.html
@@ -17,7 +17,7 @@
 
   const achy = lyrics();
 
-  for (const line of achy) {
+  for (let line of achy) {
     console.log(line);
   }
 </script>


### PR DESCRIPTION
The following SyntaxError is thrown in Firefox 48+:
`SyntaxError: missing = in const declaration`
