### PR TITLE
Add babel-loader omitted suffix

### DIFF
--- a/13 - JavaScript Modules and Using npm/es6-module-instructions.md
+++ b/13 - JavaScript Modules and Using npm/es6-module-instructions.md
@@ -23,7 +23,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel',
+        loader: 'babel-loader',
         query: {
           presets: ['es2015-native-modules']
         }


### PR DESCRIPTION
Breaking change in latest `webpack` 

```
ERROR in Entry module not found: Error: Can't resolve 'babel' in 'C:\Users\user\repo'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel'.
```