### PR TITLE
change babel to babel-loader

### DIFF
--- a/13 - JavaScript Modules and Using npm/es6modules-FINISHED/webpack.config.js
+++ b/13 - JavaScript Modules and Using npm/es6modules-FINISHED/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: 'babel',
+        loader: 'babel-loader',
         query: {
           presets: ['es2015-native-modules']
         }


### PR DESCRIPTION
babel update requires babel-loader be used when listing Webpack module loaders