### PR TITLE
Fix captain spelling

### DIFF
--- a/08 - Say Hello to ...Spread and ...Rest/rest-params.html
+++ b/08 - Say Hello to ...Spread and ...Rest/rest-params.html
@@ -19,8 +19,8 @@
   console.log(name, id, runs);
 
   const team = ['Wes', 'Kait', 'Lux', 'Sheena', 'Kelly'];
-  const [captian, assistant, ...players] = team;
-  console.log(captian, assistant, players)
+  const [captain, assistant, ...players] = team;
+  console.log(captain, assistant, players)
 
 </script>
 </body>


### PR DESCRIPTION
Fix the spelling of **captain** which is currently incorrectly spelt as **captian**.