### PR TITLE
Fix safety spelling

### DIFF
--- a/17 - Proxies/proxies-case-safety.html
+++ b/17 - Proxies/proxies-case-safety.html
@@ -17,9 +17,9 @@
     }
   };
 
-  const saftey = new Proxy({ id: 100 }, safeHandler);
+  const safety = new Proxy({ id: 100 }, safeHandler);
 
-  saftey.ID = 200;
+  safety.ID = 200;
 
 </script>
 </body>


### PR DESCRIPTION
Fix the spelling of **safety** which is currently incorrectly spelt as **saftey**.