### PR TITLE
Changes the npm install for dependencies,  getting rid of the @beta

### DIFF
--- a/13 - JavaScript Modules and Using npm/es6-module-instructions.md
+++ b/13 - JavaScript Modules and Using npm/es6-module-instructions.md
@@ -1,7 +1,7 @@
 1. First Install your dependencies:
 
 ```bash
-npm install webpack@beta babel-loader babel-core babel-preset-es2015-native-modules --save-dev
+npm install webpack babel-loader babel-core babel-preset-es2015-native-modules --save-dev
 ```
 
 2. Then, Create a `webpack.config.js` file:


### PR DESCRIPTION
At the time of this video, the beta version was being used, but this does not exist anymore. Webpack currently is on version 3.11.0. Using @beta will not give a compatible version. 