### PR TITLE
Changed  http://wesbos.com/wp-json/wp/v2/posts to https.

### DIFF
--- a/10 - Promises/multiple-promises.html
+++ b/10 - Promises/multiple-promises.html
@@ -25,7 +25,7 @@
   //     console.log(weatherInfo, tweetInfo)
   //   });
 
-  const postsPromise = fetch('http://wesbos.com/wp-json/wp/v2/posts');
+  const postsPromise = fetch('https://wesbos.com/wp-json/wp/v2/posts');
   const streetCarsPromise = fetch('http://data.ratp.fr/api/datasets/1.0/search/?q=paris');
 
   Promise

--- a/10 - Promises/promises-introduction.html
+++ b/10 - Promises/promises-introduction.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <script>
-const postsPromise = fetch('http://wesbos.com/wp-json/wp/v2/posts');
+const postsPromise = fetch('https://wesbos.com/wp-json/wp/v2/posts');
 
 postsPromise
   .then(data => data.json())


### PR DESCRIPTION
The fetch to http://wesbos.com/wp-json/wp/v2/posts fails due to the redirect and CORS policy when the user is not using a local server. A simple fix is to change the fetch urls to https so they don't require a redirect.