### PR TITLE
Removes default user agent stylesheet styling of text-decoration

### DIFF
--- a/03 - Template Strings/tagged-templates-dictionary-ANSWER.html
+++ b/03 - Template Strings/tagged-templates-dictionary-ANSWER.html
@@ -6,6 +6,7 @@
   <style>
     abbr {
       border-bottom:1px dotted grey;
+      text-decoration: none;
     }
   </style>
 </head>

--- a/03 - Template Strings/tagged-templates-dictionary-WES.html
+++ b/03 - Template Strings/tagged-templates-dictionary-WES.html
@@ -6,6 +6,7 @@
   <style>
     abbr {
       border-bottom:1px dotted grey;
+      text-decoration: none;
     }
   </style>
 </head>

--- a/03 - Template Strings/tagged-templates-dictionary.html
+++ b/03 - Template Strings/tagged-templates-dictionary.html
@@ -6,6 +6,7 @@
   <style>
     abbr {
       border-bottom:1px dotted grey;
+      text-decoration: none;
     }
   </style>
 </head>


### PR DESCRIPTION
While working through the exercise, I noticed that my browser (Chrome Version 68.0.3440.106 (Official Build) (64-bit)) added some stylings that clashed with the `border-bottom` styling.  This suppresses that default styling:

<img width="313" alt="screen shot 2018-09-18 at 3 56 55 pm" src="https://user-images.githubusercontent.com/12127480/45721100-9f126100-bb5b-11e8-9d79-0f8c33bfd1d2.png">

