### PR TITLE
Sort compareFunction corrected to take 2 params and sort correctly.

### DIFF
--- a/21 - New, Future and Experimental Language Additions/padstart-and-padend.html
+++ b/21 - New, Future and Experimental Language Additions/padstart-and-padend.html
@@ -8,7 +8,7 @@
 <body>
   <script>
     const strings = ['short', 'medium size', 'this is really really long', 'this is really reall really really really really long'];
-    const longestString = strings.sort(str => str.length).map(str => str.length)[0];
+    const longestString = strings.sort((a, b) => b.length - a.length).map(str => str.length)[0];
 
     strings.forEach(str => console.log(str.padStart(longestString)));
   </script>


### PR DESCRIPTION
From conversion in #es6 Slack channel:
 @wesbos, you may want to update video 74 of the ES6 course.
The `sort` method in V8 was changed in Sept. 2018 (https://v8.dev/blog/array-sort) to swap the order of elements passed in to the compareFunction, and I suspect it could have worked prior to that only by coincidence.  Here's how:
The sort function is supposed to take 2 parameters, the first element to compare and the second element to compare. However, there's nothing that specifies that those parameters will be in the same order as the elements in the array.  In fact, I modified Wes' example to take in 2 parameters and console.log them before returning the length of the first one (which is functionally the same value that Wes' example returns):
```const strings = ['short', 'medium size', 'this is really really long'];
const lengths = strings.sort((a, b) => console.log(`${a}, ${b}`) || a.length);
// medium size, short
// this is really really long, medium size```
See it first compare 'medium size' (as the first element) with 'small' (as the second element).  So the 2nd element in the array is passed in as the first element in the compareFunction, while the first element in the array is passed in as the second element in the compareFunction.  The value returned is 11 (the length of the first element passed in).  When the sort compareFunction returns a number > 0, it will sort item b before item a, so 'small' gets sorted before 'medium size'.  Likewise, it next compares 'this is really really long' as the first element to 'medium size' as the second element, returns 26, so sorts 'medium size' before 'this is really really long'.  The end result is that order of the elements in the array remains unchanged.
So how could Wes' example ever have worked?  Consider if the sort method passed in elements to the compareFunction in the opposite order?  The first time it would compare 'small' as the first element with 'medium size' as the 2nd element, it would return 5 (the length of the first element), and the sort would place item b before item a in the array, thus 'medium' before 'small'.  Next it would compare 'small' as the first element with 'this is really really long' as the second element, return 5, and place 'this is really really long' before 'small'.  Then it would need to do another comparison with 'medium' and 'this is really really long', return 11, and swap the order of those elements.  The end result would be as in the video, with the array coincidentally sorted from largest to smallest.
Because Wes' implementation of the compareFunction is incorrect, it was only by chance that it worked when he first created the video.