### PR TITLE
syntax fix for getCurrentPosition args array

### DIFF
--- a/20 - Async + Await/Promisifying Functions.html
+++ b/20 - Async + Await/Promisifying Functions.html
@@ -17,7 +17,7 @@
 
     function getCurrentPosition(...args) {
       return new Promise((resolve, reject) => {
-        navigator.geolocation.getCurrentPosition(...args, resolve, reject);
+        navigator.geolocation.getCurrentPosition(resolve, reject. ...args);
       });
     }
 


### PR DESCRIPTION
options array is the last arg for `getCurrentPosition`
syntax `navigator.geolocation.getCurrentPosition(success[, error[, [options]])`
source: https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition